### PR TITLE
Feature/v5.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.eldoria</groupId>
     <artifactId>bloodnight</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.2</version>
     <name>BloodNight</name>
     <url>https://www.spigotmc.org/resources/85095/</url>
     <description>Nights are not hard enough? Make them harder!</description>

--- a/src/main/java/de/eldoria/bloodnight/command/bloodnight/Reload.java
+++ b/src/main/java/de/eldoria/bloodnight/command/bloodnight/Reload.java
@@ -22,6 +22,7 @@ public class Reload extends EldoCommand {
         }
         BloodNight.getInstance().onReload();
         messageSender().sendMessage(sender, localizer().getMessage("reload.success"));
+        BloodNight.logger().info("BloodNight reloaded!");
         return true;
     }
 }

--- a/src/main/java/de/eldoria/bloodnight/config/Configuration.java
+++ b/src/main/java/de/eldoria/bloodnight/config/Configuration.java
@@ -76,6 +76,7 @@ public class Configuration {
         metrics = config.getBoolean("metrics", true);
         updateReminder = config.getBoolean("updateReminder", true);
         generalSettings = (GeneralSettings) config.get("generalSettings", new GeneralSettings());
+        worldSettings.clear();
         List<WorldSettings> worldList = ObjUtil.nonNull((List<WorldSettings>) config.get("worldSettings", new ArrayList<>()), new ArrayList<>());
         for (WorldSettings settings : worldList) {
             if (Bukkit.getWorld(settings.getWorldName()) != null) {

--- a/src/main/java/de/eldoria/bloodnight/config/worldsettings/WorldSettings.java
+++ b/src/main/java/de/eldoria/bloodnight/config/worldsettings/WorldSettings.java
@@ -29,7 +29,7 @@ public class WorldSettings implements ConfigurationSerializable {
         worldName = map.getValue("world");
         assert worldName == null : "World is null. This should not happen";
         enabled = map.getValueOrDefault("enabled", enabled);
-        enabled = map.getValueOrDefault("creeperBlockDamage", creeperBlockDamage);
+        creeperBlockDamage = map.getValueOrDefault("creeperBlockDamage", creeperBlockDamage);
         bossBarSettings = map.getValueOrDefault("bossBar", bossBarSettings);
         nightSelection = map.getValueOrDefault("nightSelection", nightSelection);
         nightSettings = map.getValueOrDefault("nightSettings", nightSettings);

--- a/src/main/java/de/eldoria/bloodnight/config/worldsettings/WorldSettings.java
+++ b/src/main/java/de/eldoria/bloodnight/config/worldsettings/WorldSettings.java
@@ -19,6 +19,7 @@ public class WorldSettings implements ConfigurationSerializable {
     private String worldName;
     private boolean enabled = false;
     private boolean creeperBlockDamage = false;
+    private boolean alwaysManageCreepers = true;
     private BossBarSettings bossBarSettings = new BossBarSettings();
     private NightSelection nightSelection = new NightSelection();
     private NightSettings nightSettings = new NightSettings();
@@ -30,6 +31,7 @@ public class WorldSettings implements ConfigurationSerializable {
         assert worldName == null : "World is null. This should not happen";
         enabled = map.getValueOrDefault("enabled", enabled);
         creeperBlockDamage = map.getValueOrDefault("creeperBlockDamage", creeperBlockDamage);
+        alwaysManageCreepers = map.getValueOrDefault("alwaysManageCreepers", alwaysManageCreepers);
         bossBarSettings = map.getValueOrDefault("bossBar", bossBarSettings);
         nightSelection = map.getValueOrDefault("nightSelection", nightSelection);
         nightSettings = map.getValueOrDefault("nightSettings", nightSettings);
@@ -46,6 +48,7 @@ public class WorldSettings implements ConfigurationSerializable {
                 .add("world", worldName)
                 .add("enabled", enabled)
                 .add("creeperBlockDamage", creeperBlockDamage)
+                .add("alwaysManageCreepers", alwaysManageCreepers)
                 .add("bossBar", bossBarSettings)
                 .add("nightSelection", nightSelection)
                 .add("nightSettings", nightSettings)

--- a/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
+++ b/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
@@ -104,8 +104,8 @@ public class BloodNight extends JavaPlugin {
     }
 
     public void onReload() {
-        localizer.setLocale(configuration.getGeneralSettings().getLanguage());
         configuration.reload();
+        localizer.setLocale(configuration.getGeneralSettings().getLanguage());
         debug = configuration.getGeneralSettings().isDebug();
 
         if (debug) {

--- a/src/main/java/de/eldoria/bloodnight/core/manager/MobManager.java
+++ b/src/main/java/de/eldoria/bloodnight/core/manager/MobManager.java
@@ -462,11 +462,17 @@ public class MobManager implements Listener, Runnable {
         WorldSettings worldSettings = configuration.getWorldSettings(event.getLocation().getWorld());
         if (!worldSettings.isEnabled()) return;
 
-        if (!worldSettings.isCreeperBlockDamage()) {
-            event.blockList().clear();
-            if (BloodNight.isDebug()) {
-                BloodNight.logger().info("Explosion is canceled? " + event.isCancelled());
-                BloodNight.logger().info("Prevented " + event.blockList().size() + " from destruction");
+        if (event.getEntity().getType() != EntityType.CREEPER) return;
+
+        boolean bloodNightActive = nightManager.isBloodNightActive(event.getLocation().getWorld());
+        if (worldSettings.isAlwaysManageCreepers() || bloodNightActive) {
+            if (!worldSettings.isCreeperBlockDamage()) {
+                int size = event.blockList().size();
+                event.blockList().clear();
+                if (BloodNight.isDebug()) {
+                    BloodNight.logger().info("Explosion is canceled? " + event.isCancelled());
+                    BloodNight.logger().info("Prevented " + size + " from destruction");
+                }
             }
         }
         executeLater.add(() ->


### PR DESCRIPTION
     This version adds a setting to enable the creeperBlockDamage setting only during an active blood night.
    It also fixes a bug which causes the plugin to load an incorrect world state.
    Thanks to Leolix for reporting. 