### PR TITLE
Feature/0.6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.eldoria</groupId>
     <artifactId>bloodnight</artifactId>
-    <version>0.6.4</version>
+    <version>0.6.5</version>
     <name>BloodNight</name>
     <url>https://www.spigotmc.org/resources/85095/</url>
     <description>Nights are not hard enough? Make them harder!</description>

--- a/src/main/java/de/eldoria/bloodnight/config/Configuration.java
+++ b/src/main/java/de/eldoria/bloodnight/config/Configuration.java
@@ -62,27 +62,24 @@ public class Configuration {
             config = plugin.getConfig();
         }
 
+
         version = config.getInt("version");
         generalSettings = (GeneralSettings) config.get("generalSettings", new GeneralSettings());
         worldSettings.clear();
         List<WorldSettings> worldList = ObjUtil.nonNull((List<WorldSettings>) config.get("worldSettings", new ArrayList<>()), new ArrayList<>());
         for (WorldSettings settings : worldList) {
-            if (Bukkit.getWorld(settings.getWorldName()) != null) {
-                worldSettings.put(settings.getWorldName(), settings);
-                if (generalSettings.isDebug()) {
-                    BloodNight.logger().info("Loading world settings for " + settings.getWorldName());
-                }
-            } else {
-                if (generalSettings.isDebug()) {
-                    BloodNight.logger().info("Didnt found a matching world for " + settings.getWorldName());
-                }
+            worldSettings.put(settings.getWorldName(), settings);
+            if (generalSettings.isDebug()) {
+                BloodNight.logger().info("Loading world settings for " + settings.getWorldName());
             }
         }
+
         for (World world : Bukkit.getWorlds()) {
             getWorldSettings(world);
         }
 
         saveConfig();
+
     }
 
     private void init() {
@@ -106,5 +103,20 @@ public class Configuration {
             BloodNight.logger().info("Saved config.");
         }
         plugin.saveConfig();
+    }
+
+    public void cleanup() {
+        List<String> invalid = new ArrayList<>();
+        BloodNight.logger().info("Performing config cleanup.");
+        for (Map.Entry<String, WorldSettings> entry : this.worldSettings.entrySet()) {
+            if (Bukkit.getWorld(entry.getKey()) == null) {
+                invalid.add(entry.getKey());
+                BloodNight.logger().info("Didnt found a matching world for " + entry.getKey() + "Will will discard Settings");
+            }
+        }
+
+        invalid.forEach(this.worldSettings::remove);
+
+        saveConfig();
     }
 }

--- a/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
+++ b/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
@@ -30,8 +30,6 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitScheduler;
-import org.bukkit.scheduler.BukkitTask;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -82,8 +80,15 @@ public class BloodNight extends EldoPlugin {
             if (configuration.getGeneralSettings().isUpdateReminder()) {
                 Updater.Butler(new ButlerUpdateData(this, Permissions.RELOAD, true,
                         configuration.getGeneralSettings().isAutoUpdater(), 4, "https://plugins.eldoria.de"))
-                        .runTaskTimerAsynchronously(this, 20*2, 20*60*60*6);
+                        .runTaskTimerAsynchronously(this, 20 * 2, 20 * 60 * 60 * 6);
             }
+
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    configuration.cleanup();
+                }
+            }.runTaskLater(this, 20);
         }
 
         onReload();


### PR DESCRIPTION
When using Multiverse, worlds will not be loaded before loading Blood Night.
This causes Blood Night to remove world settings of worlds which are at this point not present, but are present afterwards.
The config cleanup is now executed post startup.
Thanks @FurkanSB for reporting.
