### PR TITLE
Feature/0.10.0

### DIFF
--- a/BloodNight-core/pom.xml
+++ b/BloodNight-core/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>BloodNight-core</artifactId>
 
     <properties>
-        <eldoutil.version>1.6.9</eldoutil.version>
+        <eldoutil.version>1.7.3</eldoutil.version>
         <plugin.name>BloodNight</plugin.name>
         <plugin.description>Nights are not hard enough? Make them harder!</plugin.description>
         <plugin.url>https://www.spigotmc.org/resources/85095/</plugin.url>
@@ -53,6 +53,7 @@
                 <version>3.2.0</version>
                 <configuration>
                     <outputDirectory>..\..\minecraft Testserver\1.16.5\plugins</outputDirectory>
+                    <finalName>BloodNight-${revision}</finalName>
                 </configuration>
             </plugin>
         </plugins>

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/BloodNightCommand.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/BloodNightCommand.java
@@ -28,6 +28,6 @@ public class BloodNightCommand extends EldoCommand {
         registerCommand("nightSelection", new ManageNightSelection(plugin, configuration, inventoryListener));
         registerCommand("deathActions", new ManageDeathActions(plugin, configuration));
         registerCommand("reload", new Reload(plugin));
-        registerCommand("debug", new DefaultDebug(plugin, Permissions.RELOAD));
+        registerCommand("debug", new DefaultDebug(plugin, Permissions.Admin.RELOAD));
     }
 }

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/BloodNightCommand.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/BloodNightCommand.java
@@ -2,8 +2,8 @@ package de.eldoria.bloodnight.command;
 
 import de.eldoria.bloodnight.command.bloodnight.*;
 import de.eldoria.bloodnight.config.Configuration;
-import de.eldoria.bloodnight.core.manager.MobManager;
-import de.eldoria.bloodnight.core.manager.NightManager;
+import de.eldoria.bloodnight.core.manager.mobmanager.MobManager;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
 import de.eldoria.bloodnight.util.Permissions;
 import de.eldoria.eldoutilities.simplecommands.EldoCommand;
 import de.eldoria.eldoutilities.simplecommands.commands.DefaultDebug;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/CancelNight.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/CancelNight.java
@@ -30,7 +30,7 @@ public class CancelNight extends EldoCommand {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (denyAccess(sender, Permissions.CANCEL_NIGHT)) {
+        if (denyAccess(sender, Permissions.Admin.CANCEL_NIGHT)) {
             return true;
         }
 

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/CancelNight.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/CancelNight.java
@@ -1,7 +1,7 @@
 package de.eldoria.bloodnight.command.bloodnight;
 
 import de.eldoria.bloodnight.config.Configuration;
-import de.eldoria.bloodnight.core.manager.NightManager;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
 import de.eldoria.bloodnight.util.Permissions;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.simplecommands.EldoCommand;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ForceNight.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ForceNight.java
@@ -30,7 +30,7 @@ public class ForceNight extends EldoCommand {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (denyAccess(sender, Permissions.FORCE_NIGHT)) {
+        if (denyAccess(sender, Permissions.Admin.FORCE_NIGHT)) {
             return true;
         }
 

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ForceNight.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ForceNight.java
@@ -1,7 +1,7 @@
 package de.eldoria.bloodnight.command.bloodnight;
 
 import de.eldoria.bloodnight.config.Configuration;
-import de.eldoria.bloodnight.core.manager.NightManager;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
 import de.eldoria.bloodnight.util.Permissions;
 import de.eldoria.eldoutilities.localization.Replacement;
 import de.eldoria.eldoutilities.simplecommands.EldoCommand;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageDeathActions.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageDeathActions.java
@@ -34,7 +34,7 @@ public class ManageDeathActions extends EldoCommand {
             return true;
         }
 
-        if (denyAccess(sender, Permissions.MANAGE_DEATH_ACTION)) {
+        if (denyAccess(sender, Permissions.Admin.MANAGE_DEATH_ACTION)) {
             return true;
         }
 

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageMob.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageMob.java
@@ -62,7 +62,7 @@ public class ManageMob extends EldoCommand {
             return true;
         }
 
-        if (denyAccess(sender, Permissions.MANAGE_MOB)) {
+        if (denyAccess(sender, Permissions.Admin.MANAGE_MOB)) {
             return true;
         }
 

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageMobs.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageMobs.java
@@ -58,7 +58,7 @@ public class ManageMobs extends EldoCommand {
             return true;
         }
 
-        if (denyAccess(sender, Permissions.MANAGE_MOBS)) {
+        if (denyAccess(sender, Permissions.Admin.MANAGE_MOBS)) {
             return true;
         }
 

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageNight.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageNight.java
@@ -45,7 +45,7 @@ public class ManageNight extends EldoCommand {
             return true;
         }
 
-        if (denyAccess(sender, Permissions.MANAGE_NIGHT)) {
+        if (denyAccess(sender, Permissions.Admin.MANAGE_NIGHT)) {
             return true;
         }
 

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageNightSelection.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageNightSelection.java
@@ -90,7 +90,7 @@ public class ManageNightSelection extends EldoCommand {
             return true;
         }
 
-        if (denyAccess(sender, Permissions.MANAGE_WORLDS)) {
+        if (denyAccess(sender, Permissions.Admin.MANAGE_WORLDS)) {
             return true;
         }
 

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageWorlds.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/ManageWorlds.java
@@ -48,7 +48,7 @@ public class ManageWorlds extends EldoCommand {
             return true;
         }
 
-        if (denyAccess(sender, Permissions.MANAGE_WORLDS)) {
+        if (denyAccess(sender, Permissions.Admin.MANAGE_WORLDS)) {
             return true;
         }
 

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/Reload.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/Reload.java
@@ -16,7 +16,7 @@ public class Reload extends EldoCommand {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (denyAccess(sender, Permissions.RELOAD)) {
+        if (denyAccess(sender, Permissions.Admin.RELOAD)) {
             return true;
         }
         BloodNight.getInstance().onReload();

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/SpawnMob.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/SpawnMob.java
@@ -39,7 +39,7 @@ public class SpawnMob extends EldoCommand {
             return true;
         }
 
-        if (denyAccess(sender, Permissions.SPAWN_MOB)) {
+        if (denyAccess(sender, Permissions.Admin.SPAWN_MOB)) {
             return true;
         }
 

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/SpawnMob.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/command/bloodnight/SpawnMob.java
@@ -1,7 +1,7 @@
 package de.eldoria.bloodnight.command.bloodnight;
 
-import de.eldoria.bloodnight.core.manager.MobManager;
-import de.eldoria.bloodnight.core.manager.NightManager;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
+import de.eldoria.bloodnight.core.manager.mobmanager.MobManager;
 import de.eldoria.bloodnight.core.mobfactory.MobFactory;
 import de.eldoria.bloodnight.core.mobfactory.SpecialMobRegistry;
 import de.eldoria.bloodnight.util.Permissions;
@@ -67,7 +67,7 @@ public class SpawnMob extends EldoCommand {
             MobFactory mobFactory = mobFactoryByName.get();
 
             Entity entity = targetBlock.getWorld().spawnEntity(targetBlock.getLocation().add(0, 1, 0), mobFactory.getEntityType());
-            mobManager.wrapMob(entity, mobFactory);
+            mobManager.getSpecialMobManager().wrapMob(entity, mobFactory);
         } else {
             messageSender().sendError(player, "no blood night active");
         }
@@ -75,7 +75,8 @@ public class SpawnMob extends EldoCommand {
     }
 
     @Override
-    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+    public @Nullable
+    List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
         if (args.length == 1) {
             String[] strings = SpecialMobRegistry.getRegisteredMobs().stream()
                     .map(MobFactory::getMobName)

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/generalsettings/GeneralSettings.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/generalsettings/GeneralSettings.java
@@ -9,6 +9,8 @@ import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.SerializableAs;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 @Getter
@@ -28,6 +30,7 @@ public class GeneralSettings implements ConfigurationSerializable {
     private boolean beeFix = false;
     private boolean spawnerDropSuppression = true;
     private boolean ignoreSpawnerMobs = false;
+    private List<String> blockedCommands = new ArrayList<>();
 
     public GeneralSettings(Map<String, Object> objectMap) {
         TypeResolvingMap map = SerializationUtil.mapOf(objectMap);
@@ -44,6 +47,7 @@ public class GeneralSettings implements ConfigurationSerializable {
         beeFix = map.getValueOrDefault("beeFix", beeFix);
         spawnerDropSuppression = map.getValueOrDefault("spawnerDropSuppression", spawnerDropSuppression);
         ignoreSpawnerMobs = map.getValueOrDefault("ignoreSpawnerMobs", ignoreSpawnerMobs);
+        blockedCommands = map.getValueOrDefault("blockedCommands", blockedCommands);
         if (beeFix) {
             BloodNight.logger().info("§4Bee Fix is enabled. This feature should be used with care.");
         }
@@ -68,6 +72,7 @@ public class GeneralSettings implements ConfigurationSerializable {
                 .add("beeFix", beeFix)
                 .add("spawnerDropSuppression", spawnerDropSuppression)
                 .add("ignoreSpawnerMobs", ignoreSpawnerMobs)
+                .add("blockedCommands", blockedCommands)
                 .build();
     }
 }

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/generalsettings/GeneralSettings.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/generalsettings/GeneralSettings.java
@@ -27,6 +27,7 @@ public class GeneralSettings implements ConfigurationSerializable {
     private boolean autoUpdater = false;
     private boolean beeFix = false;
     private boolean spawnerDropSuppression = true;
+    private boolean ignoreSpawnerMobs = false;
 
     public GeneralSettings(Map<String, Object> objectMap) {
         TypeResolvingMap map = SerializationUtil.mapOf(objectMap);
@@ -42,6 +43,7 @@ public class GeneralSettings implements ConfigurationSerializable {
         autoUpdater = map.getValueOrDefault("autoUpdater", autoUpdater);
         beeFix = map.getValueOrDefault("beeFix", beeFix);
         spawnerDropSuppression = map.getValueOrDefault("spawnerDropSuppression", spawnerDropSuppression);
+        ignoreSpawnerMobs = map.getValueOrDefault("ignoreSpawnerMobs", ignoreSpawnerMobs);
         if (beeFix) {
             BloodNight.logger().info("§4Bee Fix is enabled. This feature should be used with care.");
         }
@@ -65,6 +67,7 @@ public class GeneralSettings implements ConfigurationSerializable {
                 .add("autoUpdater", autoUpdater)
                 .add("beeFix", beeFix)
                 .add("spawnerDropSuppression", spawnerDropSuppression)
+                .add("ignoreSpawnerMobs", ignoreSpawnerMobs)
                 .build();
     }
 }

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/worldsettings/NightSelection.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/worldsettings/NightSelection.java
@@ -1,7 +1,7 @@
 package de.eldoria.bloodnight.config.worldsettings;
 
 import de.eldoria.bloodnight.core.BloodNight;
-import de.eldoria.bloodnight.core.manager.nightmanager.NightUtil;
+import de.eldoria.bloodnight.core.manager.nightmanager.util.NightUtil;
 import de.eldoria.bloodnight.util.MoonPhase;
 import de.eldoria.eldoutilities.container.Pair;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/worldsettings/NightSettings.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/worldsettings/NightSettings.java
@@ -1,6 +1,6 @@
 package de.eldoria.bloodnight.config.worldsettings;
 
-import de.eldoria.bloodnight.core.manager.nightmanager.NightUtil;
+import de.eldoria.bloodnight.core.manager.nightmanager.util.NightUtil;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
 import lombok.Getter;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
@@ -22,9 +22,10 @@ import de.eldoria.bloodnight.config.worldsettings.mobsettings.VanillaMobSettings
 import de.eldoria.bloodnight.config.worldsettings.sound.SoundEntry;
 import de.eldoria.bloodnight.config.worldsettings.sound.SoundSettings;
 import de.eldoria.bloodnight.core.api.BloodNightAPI;
-import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
 import de.eldoria.bloodnight.core.manager.NotificationManager;
 import de.eldoria.bloodnight.core.manager.mobmanager.MobManager;
+import de.eldoria.bloodnight.core.manager.nightmanager.CommandBlocker;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
 import de.eldoria.bloodnight.core.mobfactory.MobFactory;
 import de.eldoria.bloodnight.core.mobfactory.SpecialMobRegistry;
 import de.eldoria.bloodnight.hooks.HookService;
@@ -36,10 +37,8 @@ import de.eldoria.eldoutilities.plugin.EldoPlugin;
 import de.eldoria.eldoutilities.updater.Updater;
 import de.eldoria.eldoutilities.updater.butlerupdater.ButlerUpdateData;
 import lombok.Getter;
-import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
-import org.bukkit.plugin.PluginManager;
 
 import java.util.*;
 import java.util.logging.Logger;
@@ -131,21 +130,16 @@ public class BloodNight extends EldoPlugin {
     }
 
     private void lateInit() {
-        PluginManager pm = Bukkit.getPluginManager();
-        pm.registerEvents(new NotificationManager(configuration, nightManager, hookService), this);
+        registerListener(new NotificationManager(configuration, nightManager, hookService));
     }
 
     private void registerListener() {
-        PluginManager pm = Bukkit.getPluginManager();
-
-        MessageSender messageSender = MessageSender.getPluginMessageSender(this);
         nightManager = new NightManager(configuration);
         nightManager.runTaskTimer(this, 100, 1);
-        pm.registerEvents(nightManager, this);
         mobManager = new MobManager(nightManager, configuration);
         inventoryListener = new InventoryListener(configuration);
-        pm.registerEvents(inventoryListener, this);
-        pm.registerEvents(mobManager, this);
+        CommandBlocker commandBlocker = new CommandBlocker(nightManager, configuration);
+        registerListener(commandBlocker, inventoryListener, mobManager, nightManager);
     }
 
     @Override

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
@@ -97,7 +97,7 @@ public class BloodNight extends EldoPlugin {
             enableMetrics();
 
             if (configuration.getGeneralSettings().isUpdateReminder()) {
-                Updater.Butler(new ButlerUpdateData(this, Permissions.RELOAD, true,
+                Updater.Butler(new ButlerUpdateData(this, Permissions.Admin.RELOAD, true,
                         configuration.getGeneralSettings().isAutoUpdater(), 4, "https://plugins.eldoria.de"))
                         .start();
             }

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
@@ -22,9 +22,9 @@ import de.eldoria.bloodnight.config.worldsettings.mobsettings.VanillaMobSettings
 import de.eldoria.bloodnight.config.worldsettings.sound.SoundEntry;
 import de.eldoria.bloodnight.config.worldsettings.sound.SoundSettings;
 import de.eldoria.bloodnight.core.api.BloodNightAPI;
-import de.eldoria.bloodnight.core.manager.MobManager;
-import de.eldoria.bloodnight.core.manager.NightManager;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
 import de.eldoria.bloodnight.core.manager.NotificationManager;
+import de.eldoria.bloodnight.core.manager.mobmanager.MobManager;
 import de.eldoria.bloodnight.core.mobfactory.MobFactory;
 import de.eldoria.bloodnight.core.mobfactory.SpecialMobRegistry;
 import de.eldoria.bloodnight.hooks.HookService;
@@ -140,14 +140,12 @@ public class BloodNight extends EldoPlugin {
 
         MessageSender messageSender = MessageSender.getPluginMessageSender(this);
         nightManager = new NightManager(configuration);
-        Bukkit.getScheduler().scheduleSyncRepeatingTask(this, nightManager, 100, 1);
+        nightManager.runTaskTimer(this, 100, 1);
         pm.registerEvents(nightManager, this);
         mobManager = new MobManager(nightManager, configuration);
         inventoryListener = new InventoryListener(configuration);
         pm.registerEvents(inventoryListener, this);
         pm.registerEvents(mobManager, this);
-        // Schedule mobManager
-        Bukkit.getScheduler().scheduleSyncRepeatingTask(this, mobManager, 100, 1);
     }
 
     @Override

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/api/BloodNightAPI.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/api/BloodNightAPI.java
@@ -3,8 +3,8 @@ package de.eldoria.bloodnight.core.api;
 import de.eldoria.bloodnight.api.IBloodNightAPI;
 import de.eldoria.bloodnight.config.Configuration;
 import de.eldoria.bloodnight.config.worldsettings.NightSelection;
-import de.eldoria.bloodnight.core.manager.NightManager;
-import de.eldoria.bloodnight.core.manager.nightmanager.NightUtil;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
+import de.eldoria.bloodnight.core.manager.nightmanager.util.NightUtil;
 import org.bukkit.World;
 
 import java.util.Set;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/NotificationManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/NotificationManager.java
@@ -2,6 +2,7 @@ package de.eldoria.bloodnight.core.manager;
 
 import de.eldoria.bloodnight.config.Configuration;
 import de.eldoria.bloodnight.core.BloodNight;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
 import de.eldoria.bloodnight.events.BloodNightBeginEvent;
 import de.eldoria.bloodnight.events.BloodNightEndEvent;
 import de.eldoria.bloodnight.hooks.HookService;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/mobmanager/MobManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/mobmanager/MobManager.java
@@ -1,4 +1,4 @@
-package de.eldoria.bloodnight.core.manager;
+package de.eldoria.bloodnight.core.manager.mobmanager;
 
 import de.eldoria.bloodnight.config.Configuration;
 import de.eldoria.bloodnight.config.worldsettings.WorldSettings;
@@ -7,21 +7,20 @@ import de.eldoria.bloodnight.config.worldsettings.mobsettings.MobSetting;
 import de.eldoria.bloodnight.config.worldsettings.mobsettings.MobSettings;
 import de.eldoria.bloodnight.config.worldsettings.mobsettings.VanillaMobSettings;
 import de.eldoria.bloodnight.core.BloodNight;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
 import de.eldoria.bloodnight.core.mobfactory.MobFactory;
 import de.eldoria.bloodnight.core.mobfactory.WorldMobFactory;
-import de.eldoria.bloodnight.events.BloodNightEndEvent;
 import de.eldoria.bloodnight.hooks.mythicmobs.MythicMobUtil;
 import de.eldoria.bloodnight.specialmobs.SpecialMob;
 import de.eldoria.bloodnight.specialmobs.SpecialMobUtil;
 import de.eldoria.eldoutilities.entityutils.ProjectileSender;
 import de.eldoria.eldoutilities.entityutils.ProjectileUtil;
+import de.eldoria.eldoutilities.scheduling.DelayedActions;
 import de.eldoria.eldoutilities.threading.IteratingTask;
-import lombok.NonNull;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Beehive;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
@@ -37,35 +36,37 @@ import org.bukkit.persistence.PersistentDataType;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import java.util.logging.Level;
 
-public class MobManager implements Listener, Runnable {
+public class MobManager implements Listener {
     private static final NamespacedKey SPAWNER_SPAWNED = BloodNight.getNamespacedKey("spawnerSpawned");
     private static final NamespacedKey PICKED_UP = BloodNight.getNamespacedKey("pickedUp");
-    private final Map<String, WorldMobs> mobRegistry = new HashMap<>();
     private final NightManager nightManager;
     private final Configuration configuration;
     private final ThreadLocalRandom random = ThreadLocalRandom.current();
     private final Map<String, WorldMobFactory> worldFucktories = new HashMap<>();
-    private final List<Runnable> executeLater = new ArrayList<>();
-    private final List<Runnable> executeNow = new ArrayList<>();
-    private final Queue<Entity> lostEntities = new ArrayDeque<>();
+    private final SpecialMobManager specialMobManager;
+    private final DelayedActions delayedActions;
 
     public MobManager(NightManager nightManager, Configuration configuration) {
         this.nightManager = nightManager;
         this.configuration = configuration;
+        specialMobManager = new SpecialMobManager(nightManager, configuration);
+        specialMobManager.runTaskTimer(BloodNight.getInstance(), 100, 1);
+        BloodNight.getInstance().registerListener(specialMobManager);
+        delayedActions = DelayedActions.start(BloodNight.getInstance());
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onMobSpawn(CreatureSpawnEvent event) {
         if (!nightManager.isBloodNightActive(event.getEntity().getWorld())) return;
 
-        if (event.getSpawnReason() == CreatureSpawnEvent.SpawnReason.SPAWNER
-                && configuration.getGeneralSettings().isSpawnerDropSuppression()) {
+        if (event.getSpawnReason() == CreatureSpawnEvent.SpawnReason.SPAWNER) {
             PersistentDataContainer data = event.getEntity().getPersistentDataContainer();
             data.set(SPAWNER_SPAWNED, PersistentDataType.BYTE, (byte) 1);
-            return;
+            if (configuration.getGeneralSettings().isIgnoreSpawnerMobs()) {
+                return;
+            }
         }
 
         World world = event.getLocation().getWorld();
@@ -83,197 +84,14 @@ public class MobManager implements Listener, Runnable {
 
         mobSettings.getMobByName(mobFactory.get().getMobName());
 
-        executeLater.add(() -> wrapMob(event.getEntity(), mobFactory.get()));
+        delayedActions.schedule(() -> specialMobManager.wrapMob(event.getEntity(), mobFactory.get()), 1);
     }
 
-    public void wrapMob(Entity entity, MobFactory mobFactory) {
-        // This is most likely a mounted special mob. We wont change this.
-        if (!(entity instanceof LivingEntity)) return;
-
-        // I will not try to wrap a special or mythic mob
-        if (SpecialMobUtil.isSpecialMob(entity)) return;
-        if (MythicMobUtil.isMythicMob(entity)) return;
-
-        MobSettings mobSettings = configuration.getWorldSettings(entity.getWorld().getName()).getMobSettings();
-        Optional<MobSetting> mobSetting = mobSettings.getMobByName(mobFactory.getMobName());
-
-        if (!mobSetting.isPresent()) {
-            BloodNight.logger().warning("Tried to create " + mobFactory.getMobName() + " but no settings were present.");
-            return;
-        }
-
-        SpecialMob<?> specialMob = mobFactory.wrap((LivingEntity) entity, mobSettings, mobSetting.get());
-
-        getWorldMobs(entity.getWorld()).put(entity.getUniqueId(), specialMob);
-    }
 
     private WorldMobFactory getWorldMobFactory(World world) {
         return worldFucktories.computeIfAbsent(world.getName(),
                 k -> new WorldMobFactory(configuration.getWorldSettings(world)));
     }
-
-    @Override
-    public void run() {
-        for (World bloodWorld : nightManager.getBloodWorldsSet()) {
-            getWorldMobs(bloodWorld).tick(configuration.getGeneralSettings().getMobTick());
-        }
-
-        // run runnables which should be executed this tick
-        executeNow.forEach(Runnable::run);
-        // clear executed runnables
-        executeNow.clear();
-        // schedule runnables for next tick
-        executeNow.addAll(executeLater);
-        // clear the queue
-        executeLater.clear();
-
-        for (int i = 0; i < Math.min(lostEntities.size(), 10); i++) {
-            Entity poll = lostEntities.poll();
-            if (poll.isValid()) {
-                poll.remove();
-            }
-        }
-    }
-
-    @EventHandler
-    public void onBloodNightEnd(BloodNightEndEvent event) {
-        WorldMobs worldMobs = getWorldMobs(event.getWorld());
-        worldMobs.invokeAll(SpecialMob::onEnd);
-        worldMobs.invokeAll(SpecialMob::remove);
-        worldMobs.clear();
-        IteratingTask<Entity> iteratingTask = new IteratingTask<>(event.getWorld().getEntities(), (e) ->
-        {
-            if (!(e instanceof LivingEntity)) {
-                return false;
-            }
-            if (SpecialMobUtil.isSpecialMob(e)) {
-                lostEntities.add(e);
-                return true;
-            }
-            return false;
-        }, stats -> {
-            BloodNight.logger().config(String.format("Marked %d lost enties for removal in %dms",
-                    stats.getProcessedElements(),
-                    stats.getTime()));
-        });
-
-        iteratingTask.runTaskTimer(BloodNight.getInstance(), 5, 1);
-    }
-
-    /*
-    START OF EVENT REDIRECTING SECTION
-     */
-    @EventHandler
-    public void onEntityTeleport(EntityTeleportEvent event) {
-        getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), v -> v.onTeleport(event));
-    }
-
-    @EventHandler
-    public void onProjectileShoot(ProjectileLaunchEvent event) {
-        ProjectileSender projectileSource = ProjectileUtil.getProjectileSource(event.getEntity());
-        if (projectileSource.isEntity()) {
-            getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(projectileSource.getEntity(), v -> v.onProjectileShoot(event));
-        }
-    }
-
-    @EventHandler
-    public void onProjectileHit(ProjectileHitEvent event) {
-        ProjectileSender projectileSource = ProjectileUtil.getProjectileSource(event.getEntity());
-        if (projectileSource.isEntity()) {
-            getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(projectileSource.getEntity(), m -> m.onProjectileHit(event));
-        }
-    }
-
-    @EventHandler
-    public void onDeath(EntityDeathEvent event) {
-        if (SpecialMobUtil.isSpecialMob(event.getEntity())) {
-            if (SpecialMobUtil.isExtension(event.getEntity())) {
-                Optional<UUID> baseUUID = SpecialMobUtil.getBaseUUID(event.getEntity());
-                if (!baseUUID.isPresent()) {
-                    return;
-                }
-                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(baseUUID.get(), m -> m.onExtensionDeath(event));
-            } else {
-                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onDeath(event));
-            }
-        }
-    }
-
-    @EventHandler
-    public void onKill(EntityDeathEvent event) {
-        getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onKill(event));
-    }
-
-    @EventHandler
-    public void onExplosionPrimeEvent(ExplosionPrimeEvent event) {
-        getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onExplosionPrimeEvent(event));
-    }
-
-    @EventHandler
-    public void onExplosionEvent(EntityExplodeEvent event) {
-        getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onExplosionEvent(event));
-    }
-
-    @EventHandler
-    public void onTargetEvent(EntityTargetEvent event) {
-        if (event.getTarget() != null && SpecialMobUtil.isSpecialMob(event.getTarget())) {
-            event.setCancelled(true);
-            return;
-        }
-
-        if (!SpecialMobUtil.isSpecialMob(event.getEntity())) {
-            return;
-        }
-
-        // Block that special mobs target something else than players.
-        // Otherwise they will probably kill each other.
-        if (event.getTarget() != null && event.getTarget().getType() != EntityType.PLAYER) {
-            event.setCancelled(true);
-            return;
-        }
-        if (event.getTarget() == null || event.getTarget() instanceof LivingEntity) {
-            getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onTargetEvent(event));
-        }
-    }
-
-    @EventHandler
-    public void onDamage(EntityDamageEvent event) {
-        if (SpecialMobUtil.isSpecialMob(event.getEntity())) {
-            if (SpecialMobUtil.isExtension(event.getEntity())) {
-                Optional<UUID> baseUUID = SpecialMobUtil.getBaseUUID(event.getEntity());
-                if (!baseUUID.isPresent()) {
-                    return;
-                }
-                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(baseUUID.get(), m -> m.onExtensionDamage(event));
-            } else {
-                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onDamage(event));
-            }
-        }
-    }
-
-    @EventHandler
-    public void onDamageByEntity(EntityDamageByEntityEvent event) {
-        if (SpecialMobUtil.isSpecialMob(event.getEntity())) {
-            if (SpecialMobUtil.isExtension(event.getEntity())) {
-                Optional<UUID> baseUUID = SpecialMobUtil.getBaseUUID(event.getEntity());
-                if (!baseUUID.isPresent()) {
-                    return;
-                }
-                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(baseUUID.get(), m -> m.onDamageByEntity(event));
-            } else {
-                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onDamageByEntity(event));
-            }
-        }
-    }
-
-    @EventHandler
-    public void onHit(EntityDamageByEntityEvent event) {
-        getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getDamager(), m -> m.onHit(event));
-    }
-
-    /*
-    END OF EVENT REDIRECTION SECTION
-     */
 
     /*
      * Handling of vanilla mobs damaging to players during a blood night
@@ -339,20 +157,6 @@ public class MobManager implements Listener, Runnable {
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onItemPickup(EntityPickupItemEvent event) {
-        if (!(event.getEntity() instanceof Monster) && !(event.getEntity() instanceof Boss)) return;
-        if (!configuration.getWorldSettings(event.getEntity().getWorld()).isEnabled()) return;
-        addPickupTag(event.getItem().getItemStack());
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onItemPickup(EntityDropItemEvent event) {
-        if (!(event.getEntity() instanceof Monster) && !(event.getEntity() instanceof Boss)) return;
-        if (!configuration.getWorldSettings(event.getEntity().getWorld()).isEnabled()) return;
-        removePickupTag(event.getItemDrop().getItemStack());
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityKill(EntityDeathEvent event) {
         LivingEntity entity = event.getEntity();
         Player player = event.getEntity().getKiller();
@@ -362,6 +166,12 @@ public class MobManager implements Listener, Runnable {
         if (!nightManager.isBloodNightActive(entity.getWorld())) {
             event.getDrops().forEach(this::removePickupTag);
             return;
+        }
+
+        if (configuration.getGeneralSettings().isIgnoreSpawnerMobs()) {
+            if (entity.getPersistentDataContainer().has(SPAWNER_SPAWNED, PersistentDataType.BYTE)) {
+                return;
+            }
         }
 
         WorldSettings worldSettings = configuration.getWorldSettings(entity.getWorld());
@@ -387,7 +197,7 @@ public class MobManager implements Listener, Runnable {
         // Just remove the entity.
         if (player == null) {
             BloodNight.logger().fine("Entity " + entity.getCustomName() + " was not killed by a player.");
-            getWorldMobs(event.getEntity().getWorld()).remove(event.getEntity().getUniqueId());
+            specialMobManager.remove(event.getEntity());
             return;
         }
 
@@ -472,14 +282,12 @@ public class MobManager implements Listener, Runnable {
 
             }
         }
-        executeLater.add(() ->
-                getWorldMobs(event.getLocation().getWorld())
-                        .remove(event.getEntity().getUniqueId()));
+        delayedActions.schedule(() -> specialMobManager.remove(event.getEntity()), 1);
     }
 
     @EventHandler
     private void onChunkLoad(ChunkLoadEvent event) {
-        WorldMobs worldMobs = getWorldMobs(event.getWorld());
+        WorldMobs worldMobs = specialMobManager.getWorldMobs(event.getWorld());
         for (Entity entity : event.getChunk().getEntities()) {
             Optional<SpecialMob<?>> remove = worldMobs.remove(entity.getUniqueId());
             if (SpecialMobUtil.isSpecialMob(entity)) {
@@ -496,7 +304,7 @@ public class MobManager implements Listener, Runnable {
         AtomicInteger entites = new AtomicInteger(0);
 
         // Bugfix for the sin of flying creepers with bees.
-        IteratingTask<BlockState> blockStateIterator = new IteratingTask<>(
+        new IteratingTask<>(
                 Arrays.asList(event.getChunk().getTileEntities()),
                 e -> {
                     if (e instanceof Beehive) {
@@ -532,16 +340,23 @@ public class MobManager implements Listener, Runnable {
                 },
                 s -> {
                     if (hives.get() != 0) {
-                        BloodNight.logger().config("Checked " + hives.get() + " Hive/s with " + entites.get() + " Entities and removed " + s.getProcessedElements() + " lost bees in " + s.getTime() + "ms.");
+                        BloodNight.logger().fine("Checked " + hives.get() + " Hive/s with " + entites.get() + " Entities and removed " + s.getProcessedElements() + " lost bees in " + s.getTime() + "ms.");
                     }
-                });
-
-        blockStateIterator.runTaskTimer(BloodNight.getInstance(), 0, 1);
+                }).runTaskTimer(BloodNight.getInstance(), 0, 1);
     }
 
-    @NonNull
-    private WorldMobs getWorldMobs(World world) {
-        return mobRegistry.computeIfAbsent(world.getName(), k -> new WorldMobs());
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onItemPickup(EntityPickupItemEvent event) {
+        if (!(event.getEntity() instanceof Monster) && !(event.getEntity() instanceof Boss)) return;
+        if (!configuration.getWorldSettings(event.getEntity().getWorld()).isEnabled()) return;
+        addPickupTag(event.getItem().getItemStack());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onItemPickup(EntityDropItemEvent event) {
+        if (!(event.getEntity() instanceof Monster) && !(event.getEntity() instanceof Boss)) return;
+        if (!configuration.getWorldSettings(event.getEntity().getWorld()).isEnabled()) return;
+        removePickupTag(event.getItemDrop().getItemStack());
     }
 
     private void addPickupTag(ItemStack itemStack) {
@@ -572,70 +387,7 @@ public class MobManager implements Listener, Runnable {
         return false;
     }
 
-    private static class WorldMobs {
-        private final Map<UUID, SpecialMob<?>> mobs = new HashMap<>();
-        private final Queue<SpecialMob<?>> tickQueue = new ArrayDeque<>();
-
-        private double entityTick = 0;
-
-        public void invokeIfPresent(Entity entity, Consumer<SpecialMob<?>> invoke) {
-            invokeIfPresent(entity.getUniqueId(), invoke);
-        }
-
-        public void invokeIfPresent(UUID uuid, Consumer<SpecialMob<?>> invoke) {
-            SpecialMob<?> specialMob = mobs.get(uuid);
-            if (specialMob != null) {
-                invoke.accept(specialMob);
-            }
-        }
-
-        public void invokeAll(Consumer<SpecialMob<?>> invoke) {
-            mobs.values().forEach(invoke);
-        }
-
-        public void tick(int tickDelay) {
-            if (tickQueue.isEmpty()) return;
-            entityTick += tickQueue.size() / (double) tickDelay;
-            while (entityTick > 0) {
-                if (tickQueue.isEmpty()) return;
-                SpecialMob<?> poll = tickQueue.poll();
-                if (!poll.getBaseEntity().isValid()) {
-                    remove(poll.getBaseEntity().getUniqueId());
-                    poll.remove();
-                } else {
-                    poll.tick();
-                    tickQueue.add(poll);
-                }
-                entityTick--;
-            }
-        }
-
-        public boolean isEmpty() {
-            return mobs.isEmpty();
-        }
-
-        public void put(UUID key, SpecialMob<?> value) {
-            mobs.put(key, value);
-            tickQueue.add(value);
-        }
-
-        /**
-         * Attemts to remove an entity from world mobs and the world.
-         *
-         * @param key uid of entity
-         * @return special mob if present.
-         */
-        public Optional<SpecialMob<?>> remove(UUID key) {
-            if (!mobs.containsKey(key)) return Optional.empty();
-            SpecialMob<?> removed = mobs.remove(key);
-            tickQueue.remove(removed);
-            removed.remove();
-            return Optional.of(removed);
-        }
-
-        public void clear() {
-            mobs.clear();
-            tickQueue.clear();
-        }
+    public SpecialMobManager getSpecialMobManager() {
+        return specialMobManager;
     }
 }

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/mobmanager/SpecialMobManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/mobmanager/SpecialMobManager.java
@@ -1,0 +1,229 @@
+package de.eldoria.bloodnight.core.manager.mobmanager;
+
+import de.eldoria.bloodnight.config.Configuration;
+import de.eldoria.bloodnight.config.worldsettings.mobsettings.MobSetting;
+import de.eldoria.bloodnight.config.worldsettings.mobsettings.MobSettings;
+import de.eldoria.bloodnight.core.BloodNight;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
+import de.eldoria.bloodnight.core.mobfactory.MobFactory;
+import de.eldoria.bloodnight.events.BloodNightEndEvent;
+import de.eldoria.bloodnight.hooks.mythicmobs.MythicMobUtil;
+import de.eldoria.bloodnight.specialmobs.SpecialMob;
+import de.eldoria.bloodnight.specialmobs.SpecialMobUtil;
+import de.eldoria.eldoutilities.entityutils.ProjectileSender;
+import de.eldoria.eldoutilities.entityutils.ProjectileUtil;
+import de.eldoria.eldoutilities.threading.IteratingTask;
+import lombok.NonNull;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.*;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.*;
+
+public class SpecialMobManager extends BukkitRunnable implements Listener {
+    private final Map<String, WorldMobs> mobRegistry = new HashMap<>();
+    private final NightManager nightManager;
+    private final Configuration configuration;
+    private final Queue<Entity> lostEntities = new ArrayDeque<>();
+
+
+    public SpecialMobManager(NightManager nightManager, Configuration configuration) {
+        this.nightManager = nightManager;
+        this.configuration = configuration;
+    }
+
+    public void wrapMob(Entity entity, MobFactory mobFactory) {
+        // We wont wrap anything dead... Except zombies and all the other dead stuff.
+        if (!(entity instanceof LivingEntity)) return;
+
+        // I will not try to wrap a special or mythic mob
+        if (SpecialMobUtil.isSpecialMob(entity)) return;
+        if (MythicMobUtil.isMythicMob(entity)) return;
+
+        MobSettings mobSettings = configuration.getWorldSettings(entity.getWorld().getName()).getMobSettings();
+        Optional<MobSetting> mobSetting = mobSettings.getMobByName(mobFactory.getMobName());
+
+        if (!mobSetting.isPresent()) {
+            BloodNight.logger().warning("Tried to create " + mobFactory.getMobName() + " but no settings were present.");
+            return;
+        }
+
+        SpecialMob<?> specialMob = mobFactory.wrap((LivingEntity) entity, mobSettings, mobSetting.get());
+
+        registerMob(specialMob);
+    }
+
+    @Override
+    public void run() {
+        for (World bloodWorld : nightManager.getBloodWorldsSet()) {
+            getWorldMobs(bloodWorld).tick(configuration.getGeneralSettings().getMobTick());
+        }
+
+        for (int i = 0; i < Math.min(lostEntities.size(), 10); i++) {
+            Entity poll = lostEntities.poll();
+            if (poll.isValid()) {
+                poll.remove();
+            }
+        }
+    }
+
+    @NonNull
+    public WorldMobs getWorldMobs(World world) {
+        return mobRegistry.computeIfAbsent(world.getName(), k -> new WorldMobs());
+    }
+
+    /*
+    START OF EVENT REDIRECTING SECTION
+    */
+    @EventHandler
+    public void onEntityTeleport(EntityTeleportEvent event) {
+        getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), v -> v.onTeleport(event));
+    }
+
+    @EventHandler
+    public void onProjectileShoot(ProjectileLaunchEvent event) {
+        ProjectileSender projectileSource = ProjectileUtil.getProjectileSource(event.getEntity());
+        if (projectileSource.isEntity()) {
+            getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(projectileSource.getEntity(), v -> v.onProjectileShoot(event));
+        }
+    }
+
+    @EventHandler
+    public void onProjectileHit(ProjectileHitEvent event) {
+        ProjectileSender projectileSource = ProjectileUtil.getProjectileSource(event.getEntity());
+        if (projectileSource.isEntity()) {
+            getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(projectileSource.getEntity(), m -> m.onProjectileHit(event));
+        }
+    }
+
+    @EventHandler
+    public void onDeath(EntityDeathEvent event) {
+        if (SpecialMobUtil.isSpecialMob(event.getEntity())) {
+            if (SpecialMobUtil.isExtension(event.getEntity())) {
+                Optional<UUID> baseUUID = SpecialMobUtil.getBaseUUID(event.getEntity());
+                if (!baseUUID.isPresent()) {
+                    return;
+                }
+                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(baseUUID.get(), m -> m.onExtensionDeath(event));
+            } else {
+                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onDeath(event));
+            }
+        }
+    }
+
+    @EventHandler
+    public void onKill(EntityDeathEvent event) {
+        getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onKill(event));
+    }
+
+    @EventHandler
+    public void onExplosionPrimeEvent(ExplosionPrimeEvent event) {
+        getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onExplosionPrimeEvent(event));
+    }
+
+    @EventHandler
+    public void onExplosionEvent(EntityExplodeEvent event) {
+        getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onExplosionEvent(event));
+    }
+
+    @EventHandler
+    public void onTargetEvent(EntityTargetEvent event) {
+        if (event.getTarget() != null && SpecialMobUtil.isSpecialMob(event.getTarget())) {
+            event.setCancelled(true);
+            return;
+        }
+
+        if (!SpecialMobUtil.isSpecialMob(event.getEntity())) {
+            return;
+        }
+
+        // Block that special mobs target something else than players.
+        // Otherwise they will probably kill each other.
+        if (event.getTarget() != null && event.getTarget().getType() != EntityType.PLAYER) {
+            event.setCancelled(true);
+            return;
+        }
+        if (event.getTarget() == null || event.getTarget() instanceof LivingEntity) {
+            getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onTargetEvent(event));
+        }
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageEvent event) {
+        if (SpecialMobUtil.isSpecialMob(event.getEntity())) {
+            if (SpecialMobUtil.isExtension(event.getEntity())) {
+                Optional<UUID> baseUUID = SpecialMobUtil.getBaseUUID(event.getEntity());
+                if (!baseUUID.isPresent()) {
+                    return;
+                }
+                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(baseUUID.get(), m -> m.onExtensionDamage(event));
+            } else {
+                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onDamage(event));
+            }
+        }
+    }
+
+    @EventHandler
+    public void onDamageByEntity(EntityDamageByEntityEvent event) {
+        if (SpecialMobUtil.isSpecialMob(event.getEntity())) {
+            if (SpecialMobUtil.isExtension(event.getEntity())) {
+                Optional<UUID> baseUUID = SpecialMobUtil.getBaseUUID(event.getEntity());
+                if (!baseUUID.isPresent()) {
+                    return;
+                }
+                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(baseUUID.get(), m -> m.onDamageByEntity(event));
+            } else {
+                getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getEntity(), m -> m.onDamageByEntity(event));
+            }
+        }
+    }
+
+    @EventHandler
+    public void onHit(EntityDamageByEntityEvent event) {
+        getWorldMobs(event.getEntity().getWorld()).invokeIfPresent(event.getDamager(), m -> m.onHit(event));
+    }
+
+    /*
+    END OF EVENT REDIRECTION SECTION
+     */
+
+
+    public void registerMob(SpecialMob<?> mob) {
+        World world = mob.getBaseEntity().getLocation().getWorld();
+        getWorldMobs(world).put(mob.getBaseEntity().getUniqueId(), mob);
+    }
+
+    @EventHandler
+    public void onBloodNightEnd(BloodNightEndEvent event) {
+        WorldMobs worldMobs = getWorldMobs(event.getWorld());
+        worldMobs.invokeAll(SpecialMob::onEnd);
+        worldMobs.invokeAll(SpecialMob::remove);
+        worldMobs.clear();
+        IteratingTask<Entity> iteratingTask = new IteratingTask<>(event.getWorld().getEntities(), (e) ->
+        {
+            if (!(e instanceof LivingEntity)) {
+                return false;
+            }
+            if (SpecialMobUtil.isSpecialMob(e)) {
+                lostEntities.add(e);
+                return true;
+            }
+            return false;
+        }, stats -> {
+            BloodNight.logger().config(String.format("Marked %d lost enties for removal in %dms",
+                    stats.getProcessedElements(),
+                    stats.getTime()));
+        });
+
+        iteratingTask.runTaskTimer(BloodNight.getInstance(), 5, 1);
+    }
+
+    public void remove(Entity entity) {
+        getWorldMobs(entity.getWorld()).remove(entity.getUniqueId());
+    }
+}

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/mobmanager/WorldMobs.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/mobmanager/WorldMobs.java
@@ -1,0 +1,74 @@
+package de.eldoria.bloodnight.core.manager.mobmanager;
+
+import de.eldoria.bloodnight.specialmobs.SpecialMob;
+import org.bukkit.entity.Entity;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+class WorldMobs {
+    private final Map<UUID, SpecialMob<?>> mobs = new HashMap<>();
+    private final Queue<SpecialMob<?>> tickQueue = new ArrayDeque<>();
+
+    private double entityTick = 0;
+
+    public void invokeIfPresent(Entity entity, Consumer<SpecialMob<?>> invoke) {
+        invokeIfPresent(entity.getUniqueId(), invoke);
+    }
+
+    public void invokeIfPresent(UUID uuid, Consumer<SpecialMob<?>> invoke) {
+        SpecialMob<?> specialMob = mobs.get(uuid);
+        if (specialMob != null) {
+            invoke.accept(specialMob);
+        }
+    }
+
+    public void invokeAll(Consumer<SpecialMob<?>> invoke) {
+        mobs.values().forEach(invoke);
+    }
+
+    public void tick(int tickDelay) {
+        if (tickQueue.isEmpty()) return;
+        entityTick += tickQueue.size() / (double) tickDelay;
+        while (entityTick > 0) {
+            if (tickQueue.isEmpty()) return;
+            SpecialMob<?> poll = tickQueue.poll();
+            if (!poll.getBaseEntity().isValid()) {
+                remove(poll.getBaseEntity().getUniqueId());
+                poll.remove();
+            } else {
+                poll.tick();
+                tickQueue.add(poll);
+            }
+            entityTick--;
+        }
+    }
+
+    public boolean isEmpty() {
+        return mobs.isEmpty();
+    }
+
+    public void put(UUID key, SpecialMob<?> value) {
+        mobs.put(key, value);
+        tickQueue.add(value);
+    }
+
+    /**
+     * Attemts to remove an entity from world mobs and the world.
+     *
+     * @param key uid of entity
+     * @return special mob if present.
+     */
+    public Optional<SpecialMob<?>> remove(UUID key) {
+        if (!mobs.containsKey(key)) return Optional.empty();
+        SpecialMob<?> removed = mobs.remove(key);
+        tickQueue.remove(removed);
+        removed.remove();
+        return Optional.of(removed);
+    }
+
+    public void clear() {
+        mobs.clear();
+        tickQueue.clear();
+    }
+}

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/CommandBlocker.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/CommandBlocker.java
@@ -1,0 +1,42 @@
+package de.eldoria.bloodnight.core.manager.nightmanager;
+
+import de.eldoria.bloodnight.config.Configuration;
+import de.eldoria.bloodnight.core.BloodNight;
+import de.eldoria.bloodnight.util.Permissions;
+import de.eldoria.eldoutilities.messages.MessageSender;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+public class CommandBlocker implements Listener {
+    private final NightManager nightManager;
+    private final Configuration configuration;
+    private final MessageSender sender;
+
+    public CommandBlocker(NightManager nightManager, Configuration configuration) {
+        this.nightManager = nightManager;
+        this.configuration = configuration;
+        this.sender = MessageSender.getPluginMessageSender(BloodNight.class);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onCommandPreprocessEvent(PlayerCommandPreprocessEvent event) {
+        if (!nightManager.isBloodNightActive(event.getPlayer().getWorld())) return;
+
+        if (isBlocked(event.getMessage()) && event.getPlayer().hasPermission(Permissions.Bypass.COMMAND_BLOCK)) {
+            sender.sendError(event.getPlayer(), "error.commandBlocked");
+            event.setCancelled(true);
+        }
+    }
+
+    private boolean isBlocked(String command) {
+        String lowerCommand = command.toLowerCase();
+        for (String blockedCommand : configuration.getGeneralSettings().getBlockedCommands()) {
+            if (lowerCommand.startsWith(blockedCommand.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/CommandBlocker.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/CommandBlocker.java
@@ -24,14 +24,14 @@ public class CommandBlocker implements Listener {
     public void onCommandPreprocessEvent(PlayerCommandPreprocessEvent event) {
         if (!nightManager.isBloodNightActive(event.getPlayer().getWorld())) return;
 
-        if (isBlocked(event.getMessage()) && event.getPlayer().hasPermission(Permissions.Bypass.COMMAND_BLOCK)) {
-            sender.sendError(event.getPlayer(), "error.commandBlocked");
+        if (isBlocked(event.getMessage()) && !event.getPlayer().hasPermission(Permissions.Bypass.COMMAND_BLOCK)) {
+            sender.sendLocalizedError(event.getPlayer(), "error.commandBlocked");
             event.setCancelled(true);
         }
     }
 
     private boolean isBlocked(String command) {
-        String lowerCommand = command.toLowerCase();
+        String lowerCommand = command.toLowerCase().substring(1, command.length());
         for (String blockedCommand : configuration.getGeneralSettings().getBlockedCommands()) {
             if (lowerCommand.startsWith(blockedCommand.toLowerCase())) {
                 return true;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/NightManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/NightManager.java
@@ -1,4 +1,4 @@
-package de.eldoria.bloodnight.core.manager;
+package de.eldoria.bloodnight.core.manager.nightmanager;
 
 import de.eldoria.bloodnight.config.Configuration;
 import de.eldoria.bloodnight.config.worldsettings.BossBarSettings;
@@ -8,8 +8,8 @@ import de.eldoria.bloodnight.config.worldsettings.WorldSettings;
 import de.eldoria.bloodnight.config.worldsettings.deathactions.PlayerDeathActions;
 import de.eldoria.bloodnight.config.worldsettings.deathactions.PotionEffectSettings;
 import de.eldoria.bloodnight.core.BloodNight;
-import de.eldoria.bloodnight.core.manager.nightmanager.BloodNightData;
-import de.eldoria.bloodnight.core.manager.nightmanager.NightUtil;
+import de.eldoria.bloodnight.core.manager.nightmanager.util.BloodNightData;
+import de.eldoria.bloodnight.core.manager.nightmanager.util.NightUtil;
 import de.eldoria.bloodnight.events.BloodNightBeginEvent;
 import de.eldoria.bloodnight.events.BloodNightEndEvent;
 import de.eldoria.bloodnight.specialmobs.SpecialMobUtil;
@@ -31,22 +31,17 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.*;
-import org.bukkit.event.world.TimeSkipEvent;
-import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
-public class NightManager implements Listener, Runnable {
+public class NightManager extends BukkitRunnable implements Listener {
 
     private final Configuration configuration;
-    /**
-     * Map contains for every active world a boolean if it is currently night.
-     */
-    private final Map<String, Boolean> timeState = new HashMap<>();
     /**
      * A set containing all world where a blood night is active.
      */
@@ -57,13 +52,11 @@ public class NightManager implements Listener, Runnable {
 
     private final Set<World> forceNights = new HashSet<>();
 
-    private final Map<String, Double> customTimes = new HashMap<>();
-
     private final PluginManager pluginManager = Bukkit.getPluginManager();
     private final ILocalizer localizer;
     private final MessageSender messageSender;
-
-    private int slowTick = 0;
+    private TimeManager timeManager;
+    private SoundManager soundManager;
 
     private boolean initialized = false;
 
@@ -74,24 +67,6 @@ public class NightManager implements Listener, Runnable {
         reload();
     }
 
-    // <--- World consistency ---> //
-
-    @EventHandler
-    public void onWorldLoad(WorldLoadEvent event) {
-        calcualteWorldState(event.getWorld());
-    }
-
-    // <--- Time consistency ---> //
-
-    /**
-     * Recalulate time state for immediate impact
-     *
-     * @param event time skip event
-     */
-    @EventHandler
-    public void onTimeSkip(TimeSkipEvent event) {
-        calcualteWorldState(event.getWorld());
-    }
 
     // <--- Refresh routine ---> //
 
@@ -106,47 +81,7 @@ public class NightManager implements Listener, Runnable {
             initialized = true;
         }
 
-        slowTick++;
-        if (slowTick == 5) {
-            for (World observedWorld : Bukkit.getWorlds()) {
-                calcualteWorldState(observedWorld);
-            }
-            slowTick = 0;
-
-            playRandomSound();
-
-            refreshTime();
-        }
-
-
         changeNightStates();
-    }
-
-    private void refreshTime() {
-        for (Map.Entry<World, BloodNightData> entry : getBloodWorldsMap().entrySet()) {
-            World world = entry.getKey();
-            WorldSettings settings = configuration.getWorldSettings(world.getName());
-            NightSettings ns = settings.getNightSettings();
-            if (ns.isCustomNightDuration()) {
-                double calcTicks = NightUtil.getNightTicksPerTick(world, settings);
-
-                double time = customTimes.compute(world.getName(),
-                        (key, old) -> (old == null ? world.getFullTime() : old) + calcTicks);
-
-                world.setFullTime(Math.round(time));
-            }
-
-            BloodNightData bloodNightData = getBloodNightData(world);
-            ObjUtil.nonNull(bloodNightData.getBossBar(), bossBar -> {
-                bossBar.setProgress(NightUtil.getNightProgress(world, configuration.getWorldSettings(world)));
-            });
-        }
-    }
-
-    private void playRandomSound() {
-        for (BloodNightData data : getBloodWorldsMap().values()) {
-            data.playRandomSound(configuration.getWorldSettings(data.getWorld()).getSoundSettings());
-        }
     }
 
     private void cleanup() {
@@ -164,28 +99,6 @@ public class NightManager implements Listener, Runnable {
             }
         }
         BloodNight.logger().info("Removed " + i + " hanging boss bars.");
-    }
-
-    private void calcualteWorldState(World world) {
-        boolean current = NightUtil.isNight(world, configuration.getWorldSettings(world));
-        boolean old = timeState.getOrDefault(world.getName(), false);
-
-        if (current == old) {
-            return;
-        }
-
-        timeState.put(world.getName(), current);
-
-        if (current) {
-            // A new night has begun.
-            startNight.add(world);
-            return;
-        }
-
-        if (isBloodNightActive(world)) {
-            // A blood night has ended.
-            endNight.add(world);
-        }
     }
 
     private void changeNightStates() {
@@ -270,7 +183,7 @@ public class NightManager implements Listener, Runnable {
 
         if (settings.getNightSettings().isCustomNightDuration()) {
             world.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, true);
-            customTimes.remove(world.getName());
+            timeManager.removeCustomTime(world);
         }
 
         dispatchCommands(settings.getNightSettings().getEndCommands(), world);
@@ -453,7 +366,23 @@ public class NightManager implements Listener, Runnable {
             resolveBloodNight(observedWorld);
         }
 
-        timeState.clear();
+        if (timeManager != null) {
+            if (!timeManager.isCancelled()) {
+                timeManager.cancel();
+            }
+        }
+        timeManager = new TimeManager(configuration, this);
+        BloodNight.getInstance().registerListener(timeManager);
+        timeManager.runTaskTimer(BloodNight.getInstance(), 1, 5);
+        if (soundManager != null) {
+            if (!soundManager.isCancelled()) {
+                soundManager.cancel();
+            }
+        }
+        soundManager = new SoundManager(this, configuration);
+        soundManager.runTaskTimer(BloodNight.getInstance(), 2, 5);
+
+        timeManager.reload();
         bloodWorlds.clear();
     }
 
@@ -474,7 +403,7 @@ public class NightManager implements Listener, Runnable {
      *
      * @return unmodifiable map of blood words
      */
-    private Map<World, BloodNightData> getBloodWorldsMap() {
+    public Map<World, BloodNightData> getBloodWorldsMap() {
         return Collections.unmodifiableMap(bloodWorlds);
     }
 
@@ -485,5 +414,13 @@ public class NightManager implements Listener, Runnable {
      */
     public Set<World> getBloodWorldsSet() {
         return Collections.unmodifiableSet(bloodWorlds.keySet());
+    }
+
+    public void startNight(World world) {
+        startNight.add(world);
+    }
+
+    public void endNight(World world) {
+        endNight.add(world);
     }
 }

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/NightManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/NightManager.java
@@ -120,16 +120,18 @@ public class NightManager extends BukkitRunnable implements Listener {
 
     // <--- BloodNight activation and deactivation --->
 
-    private boolean initializeBloodNight(World world) {
-        return initializeBloodNight(world, false);
+    private void initializeBloodNight(World world) {
+        initializeBloodNight(world, false);
     }
 
-    private boolean initializeBloodNight(World world, boolean force) {
+    private void initializeBloodNight(World world, boolean force) {
         WorldSettings settings = configuration.getWorldSettings(world.getName());
+
+        if (isBloodNightActive(world)) return;
 
         if (!settings.isEnabled()) {
             BloodNight.logger().fine("Blood night in world " + world.getName() + " is not enabled. Will not initialize.");
-            return true;
+            return;
         }
 
         // skip the calculation if a night should be forced.
@@ -140,8 +142,8 @@ public class NightManager extends BukkitRunnable implements Listener {
             sel.upcount();
 
             int probability = sel.getCurrentProbability(world);
-            if (probability <= 0) return true;
-            if (val > probability) return true;
+            if (probability <= 0) return;
+            if (val > probability) return;
         }
         BloodNightBeginEvent beginEvent = new BloodNightBeginEvent(world);
         // A new blood night has begun.
@@ -149,7 +151,7 @@ public class NightManager extends BukkitRunnable implements Listener {
 
         if (beginEvent.isCancelled()) {
             BloodNight.logger().fine("BloodNight in " + world.getName() + " was canceled by another plugin.");
-            return true;
+            return;
         }
         BloodNight.logger().fine("BloodNight in " + world.getName() + " activated.");
 
@@ -173,7 +175,7 @@ public class NightManager extends BukkitRunnable implements Listener {
         for (Player player : world.getPlayers()) {
             enableBloodNightForPlayer(player, world);
         }
-        return true;
+        return;
     }
 
     private void resolveBloodNight(World world) {

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/SoundManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/SoundManager.java
@@ -1,0 +1,26 @@
+package de.eldoria.bloodnight.core.manager.nightmanager;
+
+import de.eldoria.bloodnight.config.Configuration;
+import de.eldoria.bloodnight.core.manager.nightmanager.util.BloodNightData;
+import org.bukkit.scheduler.BukkitRunnable;
+
+public class SoundManager extends BukkitRunnable {
+    private final NightManager nightManager;
+    private final Configuration configuration;
+
+    public SoundManager(NightManager nightManager, Configuration configuration) {
+        this.nightManager = nightManager;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void run() {
+        playRandomSound();
+    }
+
+    private void playRandomSound() {
+        for (BloodNightData data : nightManager.getBloodWorldsMap().values()) {
+            data.playRandomSound(configuration.getWorldSettings(data.getWorld()).getSoundSettings());
+        }
+    }
+}

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/TimeManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/TimeManager.java
@@ -1,0 +1,113 @@
+package de.eldoria.bloodnight.core.manager.nightmanager;
+
+import de.eldoria.bloodnight.config.Configuration;
+import de.eldoria.bloodnight.config.worldsettings.NightSettings;
+import de.eldoria.bloodnight.config.worldsettings.WorldSettings;
+import de.eldoria.bloodnight.core.manager.nightmanager.util.BloodNightData;
+import de.eldoria.bloodnight.core.manager.nightmanager.util.NightUtil;
+import de.eldoria.eldoutilities.utils.ObjUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.TimeSkipEvent;
+import org.bukkit.event.world.WorldLoadEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TimeManager extends BukkitRunnable implements Listener {
+    private final Configuration configuration;
+    private final NightManager nightManager;
+    /**
+     * Map contains for every active world a boolean if it is currently night.
+     */
+    private final Map<String, Boolean> timeState = new HashMap<>();
+
+    private final Map<String, Double> customTimes = new HashMap<>();
+    // <--- World consistency ---> //
+
+
+    public TimeManager(Configuration configuration, NightManager nightManager) {
+        this.configuration = configuration;
+        this.nightManager = nightManager;
+    }
+
+    @EventHandler
+    public void onWorldLoad(WorldLoadEvent event) {
+        calcualteWorldState(event.getWorld());
+    }
+
+    // <--- Time consistency ---> //
+
+    /**
+     * Recalulate time state for immediate impact
+     *
+     * @param event time skip event
+     */
+    @EventHandler
+    public void onTimeSkip(TimeSkipEvent event) {
+        calcualteWorldState(event.getWorld());
+    }
+
+    @Override
+    public void run() {
+        for (World observedWorld : Bukkit.getWorlds()) {
+            calcualteWorldState(observedWorld);
+        }
+
+        refreshTime();
+    }
+
+    private void calcualteWorldState(World world) {
+        boolean current = NightUtil.isNight(world, configuration.getWorldSettings(world));
+        boolean old = timeState.getOrDefault(world.getName(), false);
+
+        if (current == old) {
+            return;
+        }
+
+        timeState.put(world.getName(), current);
+
+        if (current) {
+            // A new night has begun.
+            nightManager.startNight(world);
+            return;
+        }
+
+        if (nightManager.isBloodNightActive(world)) {
+            // A blood night has ended.
+            nightManager.endNight(world);
+        }
+    }
+
+    private void refreshTime() {
+        for (Map.Entry<World, BloodNightData> entry : nightManager.getBloodWorldsMap().entrySet()) {
+            World world = entry.getKey();
+            WorldSettings settings = configuration.getWorldSettings(world.getName());
+            NightSettings ns = settings.getNightSettings();
+            if (ns.isCustomNightDuration()) {
+                double calcTicks = NightUtil.getNightTicksPerTick(world, settings);
+
+                double time = customTimes.compute(world.getName(),
+                        (key, old) -> (old == null ? world.getFullTime() : old) + calcTicks);
+
+                world.setFullTime(Math.round(time));
+            }
+
+            BloodNightData bloodNightData = entry.getValue();
+            ObjUtil.nonNull(bloodNightData.getBossBar(), bossBar -> {
+                bossBar.setProgress(NightUtil.getNightProgress(world, configuration.getWorldSettings(world)));
+            });
+        }
+    }
+
+    public void removeCustomTime(World world) {
+        customTimes.remove(world.getName());
+    }
+
+    public void reload() {
+        timeState.clear();
+    }
+}

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/util/BloodNightData.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/util/BloodNightData.java
@@ -1,4 +1,4 @@
-package de.eldoria.bloodnight.core.manager.nightmanager;
+package de.eldoria.bloodnight.core.manager.nightmanager.util;
 
 import de.eldoria.bloodnight.config.worldsettings.sound.SoundSettings;
 import de.eldoria.bloodnight.core.BloodNight;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/util/ConsistencyCache.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/util/ConsistencyCache.java
@@ -1,4 +1,4 @@
-package de.eldoria.bloodnight.core.manager.nightmanager;
+package de.eldoria.bloodnight.core.manager.nightmanager.util;
 
 import lombok.Getter;
 import org.bukkit.OfflinePlayer;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/util/NightUtil.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/util/NightUtil.java
@@ -1,4 +1,4 @@
-package de.eldoria.bloodnight.core.manager.nightmanager;
+package de.eldoria.bloodnight.core.manager.nightmanager.util;
 
 import de.eldoria.bloodnight.config.worldsettings.NightSettings;
 import de.eldoria.bloodnight.config.worldsettings.WorldSettings;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/hooks/HookService.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/hooks/HookService.java
@@ -2,7 +2,7 @@ package de.eldoria.bloodnight.hooks;
 
 import de.eldoria.bloodnight.config.Configuration;
 import de.eldoria.bloodnight.core.BloodNight;
-import de.eldoria.bloodnight.core.manager.NightManager;
+import de.eldoria.bloodnight.core.manager.nightmanager.NightManager;
 import de.eldoria.bloodnight.hooks.mythicmobs.MythicMobsHook;
 import de.eldoria.bloodnight.hooks.placeholderapi.PlaceholderAPIHook;
 import de.eldoria.bloodnight.hooks.worldmanager.HyperverseHook;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/util/Permissions.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/util/Permissions.java
@@ -4,14 +4,25 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class Permissions {
-    public static final String ADMIN = "bloodNight.admin";
-    public static final String CANCEL_NIGHT = ADMIN + ".cancelnight";
-    public static final String FORCE_NIGHT = ADMIN + ".forcenight";
-    public static final String MANAGE_MOB = ADMIN + ".managemob";
-    public static final String MANAGE_MOBS = ADMIN + ".managemobs";
-    public static final String MANAGE_NIGHT = ADMIN + ".managenight";
-    public static final String MANAGE_WORLDS = ADMIN + ".manageworlds";
-    public static final String MANAGE_DEATH_ACTION = ADMIN + ".managedeathactions";
-    public static final String RELOAD = ADMIN + ".reload";
-    public static final String SPAWN_MOB = ADMIN + ".spawnmob";
+    @UtilityClass
+    public static class Admin {
+        public static final String ADMIN = BASE + ".admin";
+        public static final String SPAWN_MOB = ADMIN + ".spawnmob";
+        public static final String RELOAD = ADMIN + ".reload";
+        public static final String MANAGE_DEATH_ACTION = ADMIN + ".managedeathactions";
+        public static final String MANAGE_WORLDS = ADMIN + ".manageworlds";
+        public static final String MANAGE_NIGHT = ADMIN + ".managenight";
+        public static final String MANAGE_MOBS = ADMIN + ".managemobs";
+        public static final String MANAGE_MOB = ADMIN + ".managemob";
+        public static final String FORCE_NIGHT = ADMIN + ".forcenight";
+        public static final String CANCEL_NIGHT = ADMIN + ".cancelnight";
+    }
+
+    @UtilityClass
+    public static class Bypass {
+        public static final String BYPASS = BASE + ".bypass";
+        public static final String COMMAND_BLOCK = BYPASS + ".blockedcommands";
+    }
+
+    public static final String BASE = "bloodnight";
 }

--- a/BloodNight-core/src/main/resources/messages.properties
+++ b/BloodNight-core/src/main/resources/messages.properties
@@ -19,6 +19,7 @@ dialog.rightClickRemove=Right click to remove
 drops.dropsTitle=Define Drops
 drops.weight=Weight
 drops.weightTitle=Define Weight
+error.commandBlocked=This command is blocked during a blood night.
 error.console=This is not allowed from console.
 error.invalidArguments=Invalid arguments.\nSyntax: %SYNTAX%
 error.invalidBoolean=Invalid boolean

--- a/BloodNight-core/src/main/resources/messages_de_DE.properties
+++ b/BloodNight-core/src/main/resources/messages_de_DE.properties
@@ -187,4 +187,4 @@ syntax.mobGroup=mobGruppe
 syntax.value=Wert
 syntax.worldName=weltName
 value.second=Sekunde
-value.seconds=Sekunden
+value.seconds=Dieser Befehl kann während einer Blutnacht nicht benutzt werden.

--- a/BloodNight-core/src/main/resources/messages_en_US.properties
+++ b/BloodNight-core/src/main/resources/messages_en_US.properties
@@ -19,6 +19,7 @@ dialog.rightClickRemove=Right click to remove
 drops.dropsTitle=Define Drops
 drops.weight=Weight
 drops.weightTitle=Define Weight
+error.commandBlocked=This command is blocked during a blood night.
 error.console=This is not allowed from console.
 error.invalidArguments=Invalid arguments.\nSyntax: %SYNTAX%
 error.invalidBoolean=Invalid boolean

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </distributionManagement>
 
     <properties>
-        <revision>0.9.1</revision>
+        <revision>0.10.0</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
         <java.version>8</java.version>


### PR DESCRIPTION
This new version includes several things.

I splittet up the two main managers into smaller classes, which will probably increase the performance on servers with a larger player base.
The shockwave will now push players in a more horizontal way instead of rocket launching in the air.
I also fixed a bug when a mob was spawned at the death location by other plugins. Thanks to Solembum the report.
I added the ignoreSpawnerMobs option. This option will make that blood night ignores mobs completely and will not wrap or drop special loot. This was previously included in the spawnerDropSuppression. These options are now separated.
I added a blockedCommands settings in the general config. You can add commands there which should not be executed during an active blood night. The commands in the config will be matched against the start of the player command. Thanks to Fin for requesting.
