### PR TITLE
Feature/0.10.1

### DIFF
--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/worldsettings/NightSelection.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/worldsettings/NightSelection.java
@@ -144,6 +144,7 @@ public class NightSelection implements ConfigurationSerializable {
                 .add("minCurveVal", minCurveVal)
                 .add("maxCurveVal", maxCurveVal)
                 .add("interval", interval)
+                .add("intervalProbability", intervalProbability)
                 .add("curInterval", curInterval)
                 .build();
     }

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/worldsettings/NightSelection.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/worldsettings/NightSelection.java
@@ -129,7 +129,8 @@ public class NightSelection implements ConfigurationSerializable {
     }
 
     @Override
-    public @NotNull Map<String, Object> serialize() {
+    @NotNull
+    public Map<String, Object> serialize() {
         List<String> phases = this.moonPhase.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.toList());
         List<String> phasesCustom = this.phaseCustom.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.toList());
 
@@ -290,5 +291,30 @@ public class NightSelection implements ConfigurationSerializable {
          * Determine bloodnight based on a smooth curve with a fixed length and a max and min probability.
          */
         CURVE
+    }
+
+    @Override
+    public String toString() {
+        String phases;
+        switch (nightSelectionType) {
+            case RANDOM:
+                return String.format("Mode: %s | Prob: %s", nightSelectionType, probability);
+            case MOON_PHASE:
+            case REAL_MOON_PHASE:
+                phases = getMoonPhase().entrySet().stream()
+                        .map(e -> e.getKey() + ":" + e.getValue())
+                        .collect(Collectors.joining(" | "));
+                return String.format("Mode: %s | Phases: %s", nightSelectionType, phases);
+            case INTERVAL:
+                return String.format("Mode: %s | Interval %d of %d with Prob %d", nightSelectionType, curInterval, interval - 1, intervalProbability);
+            case PHASE:
+                phases = getPhaseCustom().entrySet().stream()
+                        .map(e -> e.getKey() + ":" + e.getValue())
+                        .collect(Collectors.joining(" | "));
+                return String.format("Mode: %s | Phases: %s", nightSelectionType, phases);
+            case CURVE:
+                return String.format("Mode: %s | Pos %d on curve between %d and %d", nightSelectionType, currCurvePos, minCurveVal, maxCurveVal);
+        }
+        return "NightSelection{}";
     }
 }

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/worldsettings/NightSelection.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/config/worldsettings/NightSelection.java
@@ -220,7 +220,7 @@ public class NightSelection implements ConfigurationSerializable {
                 if (!getMoonPhase().containsKey(realMoonPhase)) return 0;
                 return getPhaseProbability(realMoonPhase);
             case INTERVAL:
-                if ((getCurInterval() + nightOffset) % getInterval() != getInterval() - 1) {
+                if ((getCurInterval() + nightOffset) % getInterval() != 0) {
                     return 0;
                 }
                 return getIntervalProbability();

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
@@ -135,7 +135,7 @@ public class BloodNight extends EldoPlugin {
 
     private void registerListener() {
         nightManager = new NightManager(configuration);
-        nightManager.runTaskTimer(this, 100, 1);
+        nightManager.runTaskTimer(this, 5, 1);
         mobManager = new MobManager(nightManager, configuration);
         inventoryListener = new InventoryListener(configuration);
         CommandBlocker commandBlocker = new CommandBlocker(nightManager, configuration);

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/api/BloodNightAPI.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/api/BloodNightAPI.java
@@ -57,7 +57,6 @@ public class BloodNightAPI implements IBloodNightAPI {
 
     @Override
     public int nextProbability(World world, int offset) {
-        //if (!isBloodNightActive(world)) return 0;
         NightSelection ns = configuration.getWorldSettings(world).getNightSelection();
         return ns.getNextProbability(world, offset);
     }

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/NightManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/NightManager.java
@@ -138,10 +138,14 @@ public class NightManager extends BukkitRunnable implements Listener {
         if (!force) {
             NightSelection sel = settings.getNightSelection();
             int val = ThreadLocalRandom.current().nextInt(101);
-
             sel.upcount();
 
+            BloodNight.logger().config("Evaluating Blood Night State.");
+            BloodNight.logger().config(sel.toString());
+
             int probability = sel.getCurrentProbability(world);
+
+            BloodNight.logger().config("Current probability: " + probability);
             if (probability <= 0) return;
             if (val > probability) return;
         }
@@ -150,10 +154,10 @@ public class NightManager extends BukkitRunnable implements Listener {
         pluginManager.callEvent(beginEvent);
 
         if (beginEvent.isCancelled()) {
-            BloodNight.logger().fine("BloodNight in " + world.getName() + " was canceled by another plugin.");
+            BloodNight.logger().fine("BloodNight in " + world.getName() + " was cancelled by another plugin.");
             return;
         }
-        BloodNight.logger().fine("BloodNight in " + world.getName() + " activated.");
+        BloodNight.logger().config("BloodNight in " + world.getName() + " activated.");
 
 
         BossBar bossBar = null;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/NightManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/NightManager.java
@@ -175,10 +175,11 @@ public class NightManager extends BukkitRunnable implements Listener {
         for (Player player : world.getPlayers()) {
             enableBloodNightForPlayer(player, world);
         }
-        return;
     }
 
     private void resolveBloodNight(World world) {
+        if (!isBloodNightActive(world)) return;
+
         BloodNight.logger().fine("BloodNight in " + world.getName() + " resolved.");
 
         WorldSettings settings = configuration.getWorldSettings(world.getName());

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/TimeManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/TimeManager.java
@@ -9,6 +9,7 @@ import de.eldoria.eldoutilities.utils.ObjUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.TimeSkipEvent;
 import org.bukkit.event.world.WorldLoadEvent;
@@ -60,9 +61,10 @@ public class TimeManager extends BukkitRunnable implements Listener {
         refreshTime();
     }
 
+
     private void calcualteWorldState(World world) {
         boolean current = NightUtil.isNight(world, configuration.getWorldSettings(world));
-        boolean old = timeState.getOrDefault(world.getName(), false);
+        boolean old = timeState.getOrDefault(world.getName(), !current);
 
         if (current == old) {
             return;

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/TimeManager.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/manager/nightmanager/TimeManager.java
@@ -46,9 +46,9 @@ public class TimeManager extends BukkitRunnable implements Listener {
      *
      * @param event time skip event
      */
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onTimeSkip(TimeSkipEvent event) {
-        calcualteWorldState(event.getWorld());
+        customTimes.computeIfPresent(event.getWorld().getName(), (k, v) -> v + event.getSkipAmount());
     }
 
     @Override

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/specialmobs/mobs/creeper/EnderCreeper.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/specialmobs/mobs/creeper/EnderCreeper.java
@@ -60,7 +60,7 @@ public class EnderCreeper extends AbstractCreeper {
             Block second = first.getRelative(0, 1, 0);
             if (first.getType() == Material.AIR && second.getType() == Material.AIR) {
                 Location newLoc = first.getLocation();
-                BloodNight.logger().info("Teleport from " + getBaseEntity().getLocation() + " to " + newLoc);
+                BloodNight.logger().finer("Teleport from " + getBaseEntity().getLocation() + " to " + newLoc);
                 getBaseEntity().teleport(newLoc);
                 lastTeleport = Instant.now();
                 SpecialMobUtil.spawnParticlesAround(loc, Particle.PORTAL, 10);


### PR DESCRIPTION
This patch contains various bugfixes.

You can use now time skip commands even when you use a extended night duration.
The Exception is fixed when a blood night ends caused by a time skip
The interval probability is now serialized to config and saved
The interval probability is now read correctly.