### PR TITLE
0.10.3

### DIFF
--- a/BloodNight-core/pom.xml
+++ b/BloodNight-core/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>BloodNight-core</artifactId>
 
     <properties>
-        <eldoutil.version>1.7.3</eldoutil.version>
+        <eldoutil.version>1.8.4</eldoutil.version>
         <plugin.name>BloodNight</plugin.name>
         <plugin.description>Nights are not hard enough? Make them harder!</plugin.description>
         <plugin.url>https://www.spigotmc.org/resources/85095/</plugin.url>
@@ -61,8 +61,8 @@
 
     <repositories>
         <repository>
-            <id>jitpack.io</id> <!-- eldo utilities -->
-            <url>https://jitpack.io</url>
+            <id>EldoNexus</id> <!-- eldo utilities -->
+            <url>https://eldonexus.de/repository/maven-releases/</url>
         </repository>
         <repository> <!-- Spigot -->
             <id>spigot-repo</id>
@@ -98,21 +98,15 @@
             <version>${revision}</version>
         </dependency>
         <dependency>
-            <groupId>de.eldoria.EldoUtilities</groupId>
-            <artifactId>EldoUtilitiesCore</artifactId>
+            <groupId>de.eldoria</groupId>
+            <artifactId>eldo-util</artifactId>
             <version>${eldoutil.version}</version>
             <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bstats</groupId>
-                    <artifactId>bstats-bukkit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.4.0</version>
+            <version>4.7.0</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
+++ b/BloodNight-core/src/main/java/de/eldoria/bloodnight/core/BloodNight.java
@@ -30,7 +30,8 @@ import de.eldoria.bloodnight.core.mobfactory.MobFactory;
 import de.eldoria.bloodnight.core.mobfactory.SpecialMobRegistry;
 import de.eldoria.bloodnight.hooks.HookService;
 import de.eldoria.bloodnight.util.Permissions;
-import de.eldoria.eldoutilities.bstats.Metrics;
+import de.eldoria.eldoutilities.bstats.EldoMetrics;
+import de.eldoria.eldoutilities.bstats.charts.MultiLineChart;
 import de.eldoria.eldoutilities.localization.ILocalizer;
 import de.eldoria.eldoutilities.messages.MessageSender;
 import de.eldoria.eldoutilities.plugin.EldoPlugin;
@@ -152,11 +153,11 @@ public class BloodNight extends EldoPlugin {
     }
 
     private void enableMetrics() {
-        Metrics metrics = new Metrics(this, 9123);
+        EldoMetrics metrics = new EldoMetrics(this, 9123);
         if (metrics.isEnabled()) {
             logger().info("§2Metrics enabled. Thank you! (> ^_^ )>");
 
-            metrics.addCustomChart(new Metrics.MultiLineChart("update_settings", () -> {
+            metrics.addCustomChart(new MultiLineChart("update_settings", () -> {
                 Map<String, Integer> map = new HashMap<>();
                 map.put("Update Check", configuration.getGeneralSettings().isUpdateReminder() ? 1 : 0);
                 if (configuration.getGeneralSettings().isUpdateReminder()) {
@@ -167,7 +168,7 @@ public class BloodNight extends EldoPlugin {
                 return map;
             }));
 
-            metrics.addCustomChart(new Metrics.MultiLineChart("mob_types", () -> {
+            metrics.addCustomChart(new MultiLineChart("mob_types", () -> {
                 Map<String, Integer> map = new HashMap<>();
                 for (MobFactory factory : SpecialMobRegistry.getRegisteredMobs()) {
                     for (WorldSettings world : configuration.getWorldSettings().values()) {
@@ -184,7 +185,7 @@ public class BloodNight extends EldoPlugin {
                 return map;
             }));
 
-            metrics.addCustomChart(new Metrics.MultiLineChart("night_selection", () -> {
+            metrics.addCustomChart(new MultiLineChart("night_selection", () -> {
                 Map<String, Integer> map = new HashMap<>();
                 for (WorldSettings world : configuration.getWorldSettings().values()) {
                     if (!world.isEnabled()) continue;

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </distributionManagement>
 
     <properties>
-        <revision>0.10.2</revision>
+        <revision>0.10.3</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
         <java.version>8</java.version>


### PR DESCRIPTION
Fixing two bugs:
- Some items may have still a pickup tag which is used to block duplication glitches. These tags will now be removed when picked up again or when picked up by a hopper.
If you experience unstackable items for some reasons drop them and pick them up again.
- In some cases it was possible that mobs still drop custom drops even when the drop mode was set to vanilla. This is the case when the drop amount is not 0. The drop amount is now ignored and mobs wont drop custom drops any longer.